### PR TITLE
Fixed property declaration

### DIFF
--- a/Uber/Dashboard/DashboardCollectionController.h
+++ b/Uber/Dashboard/DashboardCollectionController.h
@@ -24,6 +24,6 @@
 
 @property (nonatomic, weak) id <DashboardCollectionDelegate> delegate;
 @property (nonatomic, strong) UICollectionView * collectionView;
-@property (nonatomic, strong) Photos * photos;
+@property (nonatomic, copy) Photos * photos;
 
 @end


### PR DESCRIPTION
It needs to be copy since we are setting this value from photos, which is a mutable object. So, to prevent the object from changing its content, we need to copy it.
